### PR TITLE
Improve sections

### DIFF
--- a/ldoc/doc.lua
+++ b/ldoc/doc.lua
@@ -276,23 +276,30 @@ function File:finish()
          if display_name == 'end' then
             this_mod.section = nil
          else
-            local summary = item.summary:gsub('%.$','')
             local lookup_name
+            local summary
             if doc.class_tag(item.type) then
                display_name = 'Class '..item.name
                lookup_name = item.name
                item.module = this_mod
                this_mod.items.by_name[item.name] = item
             else
-               display_name = summary
-               lookup_name = summary
+               local summary_type = type(item.summary)
+               local name = item.summary
+               if summary_type == "table" then
+                  local item_summary = item.summary
+                  name = item_summary[1]
+                  summary = item_summary[2]
+               end
+               display_name = name
+               lookup_name = name
                item.summary = ''
             end
             item.display_name = display_name
             this_mod.section = item
             -- the purpose of this little hack is to properly distinguish
             -- between built-in kinds and any user-defined kinds.
-            this_mod.kinds:add_kind(display_name,display_name..' ',nil,item)
+            this_mod.kinds:add_kind(display_name,display_name..' ',nil,item,summary)
             this_mod.sections:append(item)
             this_mod.sections.by_name[lookup_name:gsub('%A','_')] = item
          end

--- a/ldoc/doc.lua
+++ b/ldoc/doc.lua
@@ -342,6 +342,7 @@ function File:finish()
                local this_section = this_mod.section
                if this_section then
                   item.section = this_section.display_name
+                  item.section_id = this_section.name
                   stype = this_section.type
                end
                -- if it was a class, then if the name is unqualified then it becomes
@@ -373,6 +374,7 @@ function File:finish()
                      end
                      if item.tags.constructor then
                         item.section = item.type
+                        item.section_id = item.type
                      end
                   end
                end
@@ -381,16 +383,20 @@ function File:finish()
                   --this_section.summary = ''
                elseif item.tags.within then
                   item.section = item.tags.within
+                  item.section_id = item.tags.within
                else
                   if item.type == 'function' or item.type == 'lfunction' then
                      section_description = "Methods"
                   end
                   item.section = item.type
+                  item.section_id = item.type
                end
             elseif item.tags.within then -- ad-hoc section...
                item.section = item.tags.within
+               item.section_id = item.tags.within
             else -- otherwise, just goes into the default sections (Functions,Tables,etc)
                item.section = item.type;
+               item.section_id = item.type
             end
 
             item.module = this_mod

--- a/ldoc/tools.lua
+++ b/ldoc/tools.lua
@@ -73,7 +73,8 @@ function KindMap:__call ()
       end
       i = i + 1
       local type = klass.types_by_kind [kind].type
-      return kind, self[kind], type
+      local summary = klass.summaries_by_kind [kind]
+      return kind, self[kind], type, summary
    end
 end
 
@@ -122,13 +123,15 @@ function KindMap._class_init (klass)
    klass.types_by_kind = {} -- indexed by kind
    klass.descriptions = {} -- optional description for each kind
    klass.items_by_kind = {}  -- some kinds are items
+   klass.summaries_by_kind = {}
 end
 
 
-function KindMap.add_kind (klass,tag,kind,subnames,item)
+function KindMap.add_kind (klass,tag,kind,subnames,item,summary)
    if not klass.types_by_kind[kind] then
       klass.types_by_tag[tag] = kind
       klass.types_by_kind[kind] = {type=tag,subnames=subnames}
+      klass.summaries_by_kind[kind] = summary
       if item then
          klass.items_by_kind[kind] = item
       end


### PR DESCRIPTION
### 1st change
```lua
--- Stuff here
function Hook.SomeFunction() end

--- Hooks blah blah
-- @summary Hooks are functions that get called when events happen in-game, e.g. chat messages.
-- @section hook 

--- More Stuff here
function SomeOtherFunction() end
```

The above is already doable without this PR, but the custom "Hooks" section ends up with its display name as its identifier (`Hooks blah blah`), instead of the name provided in `@section hook`. Instead of modifying (and possibly breaking) code that makes use of `.section`, I simply added a `.section_id` to access the intended identifier.

### 2nd change

![image](https://user-images.githubusercontent.com/920910/182004357-34ecaff3-38fb-4903-bd61-174f7604be15.png)
![image](https://user-images.githubusercontent.com/920910/182004354-97fac56b-84f9-458f-b925-5e1347c5e2e4.png)


I've changed `module.kinds()` to also return the `@summary` of the section, so sections can now display a bit of extra information.

Note that I don't understand 99% of this codebase, so I simply added theses features by modifying as little of the existing code as possible. These changes are most definitely :100: pure spaghetti, so if you have a better way of doing this, feel free to rewrite it :)