### PR TITLE
Fix section anchors creating extra <p> tags

### DIFF
--- a/ldoc/markup.lua
+++ b/ldoc/markup.lua
@@ -202,10 +202,13 @@ local function process_multiline_markdown(ldoc, txt, F, filename, deflang)
       else
          local section = F and F.sections[L]
          if section then
-            append(res,('<a name="%s"></a>'):format(section))
+            local anchor = ('<a name="%s"></a>'):format(section)
+            line = resolve_inline_references(ldoc, line, err_item)
+            append(res,line .. anchor)
+         else
+            line = resolve_inline_references(ldoc, line, err_item)
+            append(res,line)
          end
-         line = resolve_inline_references(ldoc, line, err_item)
-         append(res,line)
          line = getline()
       end
    end


### PR DESCRIPTION
This change puts the section anchor tags inside of their header tag, so that the markup pipeline doesn't create a separate `<p>` tag for it.

The original behavior causes visual inconsistencies when it comes to paragraph spacing CSS rules.

Before
![image](https://user-images.githubusercontent.com/920910/182495392-39aa6818-441d-46a5-9be8-9ea595def998.png)

After
![image](https://user-images.githubusercontent.com/920910/182495381-b8ee42d0-8863-4e37-9b88-6b253eb6c298.png)